### PR TITLE
Add i18n localisations/locales for configuration page.

### DIFF
--- a/app/views/settings/_redmine_sudo_settings.html.erb
+++ b/app/views/settings/_redmine_sudo_settings.html.erb
@@ -1,16 +1,16 @@
 <fieldset>
 <p>
-  <label>User->Admin</label> 
+  <label><%= l(:become_admin_label) %></label>
   <%= text_field_tag 'settings[become_admin]', @settings['become_admin'] %>
 </p>
 <p>
-  <label>Admin->User</label> 
+  <label><%= l(:become_user_label) %></label>
   <%= text_field_tag 'settings[become_user]', @settings['become_user'] %>
 </p>
 </fieldset>
 <fieldset>
 <p>
-  <label>CSS Admin</label> 
+  <label><%= l(:css_admin_label) %></label>
   <%= text_area_tag 'settings[additional_css]', @settings['additional_css'], :size => '50x5' %>
 </p>
 </fieldset>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,0 +1,4 @@
+de:
+  become_admin_label: 'Benutzer->Administrator'
+  become_user_label: 'Administrator->Benutzer'
+  css_admin_label: CSS-Regeln Administrator

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,4 @@
+en:
+  become_admin_label: 'User->Admin'
+  become_user_label: 'Admin->User'
+  css_admin_label: CSS rules Admin

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,4 @@
+en:
+  become_admin_label: 'Usuario->Administrador'
+  become_user_label: 'Administrador->Usuario'
+  css_admin_label: Reglas CSS Administrador

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,4 +1,4 @@
-en:
+es:
   become_admin_label: 'Usuario->Administrador'
   become_user_label: 'Administrador->Usuario'
   css_admin_label: Reglas CSS Administrador

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,4 @@
+fr:
+  become_admin_label: 'Utilisateur->Administrateur'
+  become_user_label: 'Administrateur->Utilisateur'
+  css_admin_label: Règles CSS de l'administrateur

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,0 +1,4 @@
+nl:
+  become_admin_label: 'Gebruiker->Beheerder'
+  become_user_label: 'Beheerder->Gebruiker'
+  css_admin_label: CSS-regels voor beheerder

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,0 +1,4 @@
+ru:
+  become_admin_label: 'Пользователь->Администратор'
+  become_user_label: 'Администратор->Пользователь'
+  css_admin_label: CSS Администратор

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1,0 +1,4 @@
+tr:
+  become_admin_label: 'Kullanıcı->Yönetici'
+  become_user_label: 'Yönetici->Kullanıcı'
+  css_admin_label: CSS kuralları Yönetici


### PR DESCRIPTION
Just a small enhancement by adding localisations for the configuration page.
Supported languages: German, English, Spanish, French, Dutch, Russian and Turkish.